### PR TITLE
Agregar funcionalidad para mostrar/ocultar contraseña en Login

### DIFF
--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -2,11 +2,13 @@ import { useState } from "react";
 import { navigate } from "../Link.jsx";
 import logo from "../assets/logouamcuaji.png";
 import { loginUser } from "../services/auth.js";
+import { AiOutlineEye, AiOutlineEyeInvisible } from "react-icons/ai";
 // JSX PARA PROBAR LOS ESTILOS.
 export default function Login() {
   const [email, setEmail] = useState("");
 
   const [password, setPassword] = useState("");
+  const [showPassword, setShowPassword] = useState(false);
 
   const loginUsuario = async (e) => {
     e.preventDefault();
@@ -70,15 +72,26 @@ export default function Login() {
             </div>
             <div className="flex flex-col items-start">
               <label className="mb-1 text-sm font-semibold">Contraseña</label>
-              <input
-                type="password"
-                className="w-full shadow-md border border-gray-300 rounded-xl px-4 py-2"
-                placeholder="***********"
-                onChange={(e) => setPassword(e.target.value)}
-                required
-              />
-            </div>
+              <div className="relative w-full">
+                <input
+                  type={showPassword ? "text" : "password"}
+                  className="w-full shadow-md border border-gray-300 rounded-xl px-4 py-2 pr-10"
+                  placeholder="***********"
+                  onChange={(e) => setPassword(e.target.value)}
+                  required
+                />
+                <button
+                  type="button"
+                  onClick={() => setShowPassword(!showPassword)}
+                  className="absolute right-3 top-2.5 text-gray-600 hover:text-gray-800 cursor-pointer"
+                  aria-label="Toggle password visibility"
+                >
+                  {showPassword ? <AiOutlineEye /> : <AiOutlineEyeInvisible />}
+                </button>
+              </div>
             {/* DIV PARA EL CHECKBOX DE SESION*/}
+            </div>
+            
             <div className="flex items-center gap-2">
               <input
                 type="checkbox"


### PR DESCRIPTION
##Cambios realizados
- Agregado estado  `showPassword` para manejar visibilidad
- Agregado ícono de ojo (toggle) junto al input de contraseña
- Implementada función para alternar entre input type="password" e input type="text"
- Mejorada la experiencia de usuario al permitir verificar la contraseña antes de enviar

## Razón del cambio
Muchos usuarios escriben mal su contraseña y no pueden verificarla antes de enviar. 
Esta funcionalidad es estándar en formularios modernos.

## Testing
1. Ve a la página de login
2. Escribe algo en el campo de contraseña
3. Haz clic en el ícono de ojo
4. Verifica que la contraseña se muestre en texto plano
5. Haz clic nuevamente para ocultarla

## Screenshots
<img width="451" height="598" alt="imagen" src="https://github.com/user-attachments/assets/6e74f4a1-9d39-4b9c-9422-cbbe0c5158fc" />
<img width="451" height="598" alt="imagen" src="https://github.com/user-attachments/assets/ec5bdb77-dcd3-4c82-a2d1-584e0f7b6e4d" />
